### PR TITLE
Add implementation for rename, lstat and readlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ install:
 test:
 	py.test
 
+retest:
+	py.test -vvs --lf
+
 coverage:
 	py.test --cov=mocksftp --cov-report=term-missing -p no:mocksftp
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     version="0.1.0",
     description="Mock SFTP server for testing purposes",
     long_description=long_description,
-    url="https://github.com/carletes/mock-ssh-server",
+    url="https://github.com/LabD/python-mocksftp",
     author="Michael van Tellingen",
     author_email="michaelvantellingen@gmail.com",
     license="MIT",


### PR DESCRIPTION
* You can use `rename()` (aka move), `lstat()` and `readlink()` now.
* Added `make retest` command
* Fixed symlink following by `stat()`
* Fixed homepage link in `setup.py`